### PR TITLE
Feat: useInput 기능 추가

### DIFF
--- a/src/hooks/useinput.ts
+++ b/src/hooks/useinput.ts
@@ -1,0 +1,13 @@
+import { Dispatch, SetStateAction, useCallback, useState } from "react";
+
+type ReturnType<T> = [T, (e: any) => void, Dispatch<SetStateAction<T>>];
+
+export default function useInput<T extends string>(initialValue: T): ReturnType<T> {
+  const [value, setValue] = useState(initialValue);
+
+  const handler = useCallback((event: any) => {
+    setValue(event.target.value);
+  }, []);
+
+  return [value, handler, setValue];
+}

--- a/src/hooks/useinput.ts
+++ b/src/hooks/useinput.ts
@@ -1,8 +1,10 @@
-import { Dispatch, SetStateAction, useCallback, useState } from "react";
+import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 
 type ReturnType<T> = [T, (e: any) => void, Dispatch<SetStateAction<T>>];
 
-export default function useInput<T extends string>(initialValue: T): ReturnType<T> {
+export default function useInput<T extends string>(
+  initialValue: T
+): ReturnType<T> {
   const [value, setValue] = useState(initialValue);
 
   const handler = useCallback((event: any) => {


### PR DESCRIPTION
useinput.ts
```ts
export default function useInput<T extends string>(
  initialValue: T
): ReturnType<T> {
  const [value, setValue] = useState(initialValue);

  const handler = useCallback((event: any) => {
    setValue(event.target.value);
  }, []);

  return [value, handler, setValue];
}
```

제가 사용했을 때는 
```ts
const [email, onChangeEmail] = useInput<string>("");
const [todo, onChangeTodo, setTodo] = useInput<string>("");
```
```html
 <input data-testid="email-input" id="email-input" type="email" placeholder="email" value={email} onChange={onChangeEmail} required />
```
이렇게 email이나 todo와 같은 value의 타입을 useInput에 적어주고 onChangeEmail이나 onChangeTodo를 사용해서 input에 입력을 하면 value값을 변경해주는 방식을 사용하였습니다. 